### PR TITLE
fixed error on line 323 that was crashing node, wrote a couple of tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,7 +319,7 @@ function getFullListByQuery(query, location, resolve, reject){
                 /*
                     Creates another request if id is less than query.limit
                 */
-                if(k < query.limit){
+                if(k < query.limit && r.data.next_page_cursor){
                     var s = JSON.parse(r.data.next_page_cursor);
                     query.search_after = s.search_after;
                     query.cursor_id = s.cursor_id;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+// jest.config.js
+module.exports = {
+  verbose: true,
+  bail: false
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The unofficial OfferUp API",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest -i --silent=false"
   },
   "repository": {
     "type": "git",
@@ -32,5 +32,8 @@
   },
   "directories": {
     "doc": "docs"
+  },
+  "devDependencies": {
+    "jest": "^23.5.0"
   }
 }

--- a/spec/testRequest.js
+++ b/spec/testRequest.js
@@ -1,0 +1,63 @@
+const OfferUp = require("../index");
+
+const testMethods = {
+  goodRequest: function() {
+    return new Promise((resolve, reject) => {
+      OfferUp.getFullListByQuery({
+        location: "Chicago", // required
+        search: "iphone", // required
+        radius: 50,
+        limit: 100,
+        price_min: 100,
+        price_max: 1000
+      })
+        .then(function success(response) {
+          resolve(response);
+        })
+        .catch(err => {
+          reject(true);
+        });
+    });
+  },
+  badRequest: function() {
+    return new Promise((resolve, reject) => {
+      OfferUp.getFullListByQuery({
+        location: "Chicago", // required
+        search: "bjibiuuiJDbu", // required
+        radius: 50,
+        limit: 100,
+        price_min: 100,
+        price_max: 1000
+      })
+        .then(function success(response) {
+          resolve(response);
+        })
+        .catch(err => {
+          reject(true);
+        });
+    });
+  }
+};
+
+module.exports = testMethods;
+
+/***
+ * WRITTEN TO FIX THIS BUG THAT WOULD CRASH NODE IF A RESULT DIDN'T RETURN RESULTS: 
+ * SyntaxError: Unexpected token u in JSON at position 0
+        at JSON.parse (<anonymous>)
+
+      321 |                 
+      322 |                 if(k < query.limit){
+        > 323 |                     var s = JSON.parse(r.data.next_page_cursor);
+              |                                  ^
+          324 |                     query.search_after = s.search_after;
+          325 |                     query.cursor_id = s.cursor_id;
+          326 |                     q.push(query)
+    
+          at Request.parse [as _rp_callbackOrig] (index.js:323:34)
+          at Request.plumbing.callback (node_modules/request-promise-core/lib/plumbing.js:76:39)
+          at Request.RP$callback [as _callback] (node_modules/request-promise-core/lib/plumbing.js:46:31)
+          at Request.self.callback (node_modules/request/request.js:185:22)
+          at Request.<anonymous> (node_modules/request/request.js:1161:10)
+          at IncomingMessage.<anonymous> (node_modules/request/request.js:1083:12)
+ * */

--- a/spec/testRequest.test.js
+++ b/spec/testRequest.test.js
@@ -1,0 +1,26 @@
+const testRequest = require("./testRequest");
+
+test("makes a request and returns a response", async () => {
+  expect.assertions(1);
+  await testRequest
+    .goodRequest()
+    .then(result => {
+      expect(Array.isArray(result)).toBeTruthy();
+    })
+    .catch(err => {
+      expect(1).toEqual(2); // just forcing failure because it should not get to this
+    });
+});
+
+test("handles query with no results without crashing node", async () => {
+  expect.assertions(1);
+  await testRequest
+    .badRequest()
+    .then(result => {
+      console.log("instead of a thrown error you get an empty array", result);
+      expect(Array.isArray(result)).toBeTruthy();
+    })
+    .catch(err => {
+      expect(1).toEqual(2); // just forcing failure because it should not get to this
+    });
+});


### PR DESCRIPTION
Thanks for this npm package! I was having an issue with it and decided to fix it. Basically if I sent a search term that didn't return any results it would error out and crash my node instance. The fix was simple and now it will just return an empty array. I wrote a couple of quick tests just to prove that it works. If you want to recreate the original error then delete my change in index.js on line 323 and run the tests.